### PR TITLE
Add ASN support from db-ip.com ASN database

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,23 @@ ipconf.cc is a side project at Randomicu organization.
 
 ## Build notes
 
-This project uses Maven.
+This project uses Maven for building production / development docker images.
 
-Before building, edit `.env` file.
+Currently, there only two environments are configured: production and development.
+
+Before building, edit the `.env` file.
 
 ### Manual production build
 
 1. Build image and tag it with the closest git tag: `./mvnw -DskipTests -Pproduction spring-boot:build-image`
 2. Tag docker image with `latest` tag: `docker tag image:1.0.0 image:latest` 
 3. Push it twice: `docker push image:1.0.0 && docker push image:latest`
-4. Download latest db-ip database and place it to `./mmdb` folder
+4. Download latest db-ip databases (ASN Lite, City Lite) and place it to `./mmdb` folder
 5. Start container: `docker run --rm -p 8080:8080 --volume "${PWD}/mmdb:/workspace/mmdb" --env "SENTRY_DSN=$SENTRY_DSN" image:1.0.0`
 
 ## Thanks
 
-Randomicu & related projects was built with [Jetbrains](https://www.jetbrains.com/?from=RandomicuQAAPI) PyCharm and Intellij IDEA.
+Ipconf & related projects were built with [Jetbrains](https://www.jetbrains.com/?from=RandomicuQAAPI) PyCharm Professional
+and Intellij IDEA Ultimate.
 
-IP Geolocation powered by [db-ip.com](https://db-ip.com/).
+IP Geolocation is powered by [db-ip.com](https://db-ip.com/).

--- a/src/main/java/cc/ipconf/ipconfcc/api/Paths.java
+++ b/src/main/java/cc/ipconf/ipconfcc/api/Paths.java
@@ -9,6 +9,7 @@ public class Paths {
   public static final String INFO_ENDPOINT = "/info";
   public static final String COUNTRY_ENDPOINT = "/location/country";
   public static final String CITY_ENDPOINT = "/location/city";
+  public static final String ASN_ENDPOINT = "/asn";
 
 
   private Paths() {

--- a/src/main/java/cc/ipconf/ipconfcc/config/AppConfig.java
+++ b/src/main/java/cc/ipconf/ipconfcc/config/AppConfig.java
@@ -1,0 +1,17 @@
+package cc.ipconf.ipconfcc.config;
+
+import java.nio.file.Path;
+import javax.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+
+@Slf4j
+@Configuration
+public class AppConfig {
+
+  @PostConstruct
+  public void printCurrentWorkingDirectory() {
+    log.info("Current working directory: {}", Path.of("").toAbsolutePath());
+  }
+
+}

--- a/src/main/java/cc/ipconf/ipconfcc/config/MMDBLoaderConfig.java
+++ b/src/main/java/cc/ipconf/ipconfcc/config/MMDBLoaderConfig.java
@@ -15,26 +15,45 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class MMDBLoaderConfig {
 
-  @Value("${ipaddr.mmdb.city-filename}")
+  @Value("${ipconf.mmdb.city-database.filename}")
   private String cityDatabaseName;
 
-  @Value("${ipaddr.mmdb.city-database-path}")
+  @Value("${ipconf.mmdb.city-database.path}")
   private String cityDatabasePath;
 
-  @Bean
-  public DatabaseReader getDatabaseReader() {
-    log.info("Current working directory: {}", Path.of("").toAbsolutePath());
+  @Value("${ipconf.mmdb.asn-database.filename}")
+  private String asnDatabaseName;
 
+  @Value("${ipconf.mmdb.asn-database.path}")
+  private String asnDatabasePath;
+
+  @Bean
+  public DatabaseReader getCityDatabaseReader() {
     File cityDb = new File(Paths.get(cityDatabasePath).toString());
     DatabaseReader.Builder databaseReaderBuilder = new DatabaseReader.Builder(cityDb);
-    log.info("Full database file path: {}", cityDb.getAbsolutePath());
+    log.info("Full City database file path: {}", cityDb.getAbsolutePath());
 
     try {
-      log.info("Loading database: {}", cityDatabaseName);
+      log.info("Loading City database: {}", cityDatabaseName);
       return databaseReaderBuilder.build();
     } catch (IOException e) {
       Sentry.captureException(e);
-      throw new IllegalArgumentException("Database file not found");
+      throw new IllegalArgumentException("City database file not found");
+    }
+  }
+
+  @Bean
+  public DatabaseReader getAsnDatabaseReader() {
+    File asnDb = new File(Paths.get(asnDatabasePath).toString());
+    DatabaseReader.Builder databaseReaderBuilder = new DatabaseReader.Builder(asnDb);
+    log.info("Full ASN database file path: {}", asnDb.getAbsolutePath());
+
+    try {
+      log.info("Loading ASN database: {}", asnDatabaseName);
+      return databaseReaderBuilder.build();
+    } catch (IOException e) {
+      Sentry.captureException(e);
+      throw new IllegalArgumentException("ASN database file not found");
     }
   }
 

--- a/src/main/java/cc/ipconf/ipconfcc/controllers/AsnController.java
+++ b/src/main/java/cc/ipconf/ipconfcc/controllers/AsnController.java
@@ -1,0 +1,65 @@
+package cc.ipconf.ipconfcc.controllers;
+
+import cc.ipconf.ipconfcc.api.Paths;
+import cc.ipconf.ipconfcc.dto.AsnDto;
+import cc.ipconf.ipconfcc.dto.IpAddressDto;
+import cc.ipconf.ipconfcc.services.AsnService;
+import cc.ipconf.ipconfcc.services.RequestService;
+import javax.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping(Paths.API_ROOT_PATH + Paths.API_VERSION)
+public class AsnController {
+
+  private final AsnService asnService;
+  private final RequestService requestService;
+
+  @Autowired
+  public AsnController(AsnService asnService, RequestService requestService) {
+    this.asnService = asnService;
+    this.requestService = requestService;
+  }
+
+  @GetMapping(value = Paths.ASN_ENDPOINT, produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<AsnDto> showASNJson(HttpServletRequest request) {
+    log.info("Replying with application/json");
+
+    IpAddressDto ipAddress = requestService.getClientIpAddress(request);
+    log.info("Client IP address from requestService: {}", ipAddress.getIpAddress());
+
+    AsnDto asn = asnService.getAsn(ipAddress.getIpAddress());
+    log.info("Client ASN (AsnDto) from asnService: {}", asn);
+
+    return new ResponseEntity<>(asn, HttpStatus.OK);
+  }
+
+  @GetMapping(value = Paths.ASN_ENDPOINT, consumes = MediaType.ALL_VALUE, produces = MediaType.TEXT_PLAIN_VALUE)
+  public ResponseEntity<String> showASNText(HttpServletRequest request) {
+    log.info("Replying with plain/text");
+
+    IpAddressDto ipAddress = requestService.getClientIpAddress(request);
+    log.info("Client IP address from requestService: {}", ipAddress.getIpAddress());
+
+    AsnDto asnDto = asnService.getAsn(ipAddress.getIpAddress());
+    log.info("Client ASN (AsnDto) from asnService: {}", asnDto);
+
+    int asNumber = asnDto.getAutonomousSystemNumber();
+    String asnOrganization = asnDto.getAutonomousSystemOrganization();
+    String asnNetworkAddress = asnDto.getNetworkDto().getNetworkAddress().getHostAddress();
+    int asnPrefixLength = asnDto.getNetworkDto().getPrefixLength();
+
+    String response = "%d,%s,%s/%d".formatted(asNumber, asnOrganization, asnNetworkAddress, asnPrefixLength);
+
+    return new ResponseEntity<>(response, HttpStatus.OK);
+  }
+
+}

--- a/src/main/java/cc/ipconf/ipconfcc/dto/AsnDto.java
+++ b/src/main/java/cc/ipconf/ipconfcc/dto/AsnDto.java
@@ -2,23 +2,21 @@ package cc.ipconf.ipconfcc.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonPropertyOrder({"ipAddress", "city", "country", "asn"})
-public class InfoDto {
+public class AsnDto {
 
-  @JsonProperty("ip_address")
-  String ipAddress;
+  @JsonProperty("asn")
+  Integer autonomousSystemNumber;
 
-  CountryDto country;
+  @JsonProperty("organization")
+  String autonomousSystemOrganization;
 
-  String city;
-
-  AsnDto asn;
+  @JsonProperty("network")
+  NetworkDto networkDto;
 
 }

--- a/src/main/java/cc/ipconf/ipconfcc/dto/NetworkDto.java
+++ b/src/main/java/cc/ipconf/ipconfcc/dto/NetworkDto.java
@@ -1,0 +1,38 @@
+package cc.ipconf.ipconfcc.dto;
+
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.maxmind.db.Network;
+import java.net.InetAddress;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.jetbrains.annotations.NotNull;
+
+@Data
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonPropertyOrder({"networkAddress", "prefixLength", "fullNetworkAddress"})
+public class NetworkDto {
+
+  @JsonProperty("prefix_length")
+  private int prefixLength;
+
+  @JsonProperty("network_address")
+  private InetAddress networkAddress;
+
+  @JsonProperty("route")
+  private String fullNetworkAddress;
+
+
+  public static @NotNull NetworkDto convertNetworkObjToNetworkDto(@NotNull Network networkObj) {
+    NetworkDto dto = new NetworkDto();
+    dto.setPrefixLength(networkObj.getPrefixLength());
+    dto.setNetworkAddress(networkObj.getNetworkAddress());
+    dto.setFullNetworkAddress("%s/%d".formatted(networkObj.getNetworkAddress().getHostAddress(), networkObj.getPrefixLength()));
+
+    return dto;
+  }
+
+}

--- a/src/main/java/cc/ipconf/ipconfcc/services/AsnService.java
+++ b/src/main/java/cc/ipconf/ipconfcc/services/AsnService.java
@@ -1,0 +1,9 @@
+package cc.ipconf.ipconfcc.services;
+
+import cc.ipconf.ipconfcc.dto.AsnDto;
+
+public interface AsnService {
+
+  AsnDto getAsn(String ipAddress);
+
+}

--- a/src/main/java/cc/ipconf/ipconfcc/services/AsnServiceImpl.java
+++ b/src/main/java/cc/ipconf/ipconfcc/services/AsnServiceImpl.java
@@ -1,0 +1,66 @@
+package cc.ipconf.ipconfcc.services;
+
+import cc.ipconf.ipconfcc.config.MMDBLoaderConfig;
+import cc.ipconf.ipconfcc.dto.AsnDto;
+import cc.ipconf.ipconfcc.dto.NetworkDto;
+import com.maxmind.geoip2.DatabaseReader;
+import com.maxmind.geoip2.exception.GeoIp2Exception;
+import com.maxmind.geoip2.model.AsnResponse;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class AsnServiceImpl implements AsnService {
+
+  private final MMDBLoaderConfig mmdbLoader;
+
+  public AsnServiceImpl(MMDBLoaderConfig mmdbLoader) {
+    this.mmdbLoader = mmdbLoader;
+  }
+
+
+  @Override
+  public AsnDto getAsn(String ipAddress) {
+    DatabaseReader reader = mmdbLoader.getAsnDatabaseReader();
+
+    InetAddress ip = this.getIpAddress(ipAddress);
+    AsnResponse asnResponse = this.getAsnResponse(reader, ip);
+
+    return this.convertAsnResponseToAsnDto(asnResponse);
+  }
+
+  private InetAddress getIpAddress(String clientIpAddress) {
+    try {
+      return InetAddress.getByName(clientIpAddress);
+    } catch (UnknownHostException e) {
+      throw new IllegalArgumentException("IP address is not valid");
+    }
+  }
+
+  private AsnResponse getAsnResponse(@NotNull DatabaseReader reader, InetAddress ip) {
+    try {
+      return reader.asn(ip);
+    } catch (IOException | GeoIp2Exception e) {
+      log.error("Error when trying to get ASN from database ");
+
+      throw new RuntimeException(e.getMessage());
+    }
+  }
+
+  private @NotNull AsnDto convertAsnResponseToAsnDto(@NotNull AsnResponse asnResponse) {
+    AsnDto asnDto = new AsnDto();
+    NetworkDto networkDto = NetworkDto.convertNetworkObjToNetworkDto(asnResponse.getNetwork());
+
+    asnDto.setAutonomousSystemNumber(asnResponse.getAutonomousSystemNumber());
+    asnDto.setNetworkDto(networkDto);
+    asnDto.setAutonomousSystemOrganization(asnResponse.getAutonomousSystemOrganization());
+
+    return asnDto;
+  }
+
+}

--- a/src/main/java/cc/ipconf/ipconfcc/services/InfoServiceImpl.java
+++ b/src/main/java/cc/ipconf/ipconfcc/services/InfoServiceImpl.java
@@ -1,5 +1,6 @@
 package cc.ipconf.ipconfcc.services;
 
+import cc.ipconf.ipconfcc.dto.AsnDto;
 import cc.ipconf.ipconfcc.dto.CityDto;
 import cc.ipconf.ipconfcc.dto.CountryDto;
 import cc.ipconf.ipconfcc.dto.InfoDto;
@@ -15,11 +16,13 @@ public class InfoServiceImpl implements InfoService {
 
   private final LocationService locationService;
   private final RequestService requestService;
+  private final AsnService asnService;
 
   @Autowired
-  public InfoServiceImpl(LocationService locationService, RequestService requestService) {
+  public InfoServiceImpl(LocationService locationService, RequestService requestService, AsnService asnService) {
     this.locationService = locationService;
     this.requestService = requestService;
+    this.asnService = asnService;
   }
 
   @Override
@@ -29,10 +32,12 @@ public class InfoServiceImpl implements InfoService {
     IpAddressDto ipAddressDto = requestService.getClientIpAddress(request);
     CountryDto countryDto = locationService.getCountry(ipAddressDto.getIpAddress());
     CityDto cityDto = locationService.getCity(ipAddressDto.getIpAddress());
+    AsnDto asnDto = asnService.getAsn(ipAddressDto.getIpAddress());
 
     infoDto.setIpAddress(ipAddressDto.getIpAddress());
     infoDto.setCountry(countryDto);
     infoDto.setCity(cityDto.getCity());
+    infoDto.setAsn(asnDto);
 
     return infoDto;
   }

--- a/src/main/java/cc/ipconf/ipconfcc/services/LocationServiceImpl.java
+++ b/src/main/java/cc/ipconf/ipconfcc/services/LocationServiceImpl.java
@@ -1,12 +1,12 @@
 package cc.ipconf.ipconfcc.services;
 
+import cc.ipconf.ipconfcc.config.MMDBLoaderConfig;
+import cc.ipconf.ipconfcc.dto.CityDto;
+import cc.ipconf.ipconfcc.dto.CountryDto;
 import com.maxmind.geoip2.DatabaseReader;
 import com.maxmind.geoip2.exception.GeoIp2Exception;
 import com.maxmind.geoip2.model.CityResponse;
 import com.maxmind.geoip2.model.CountryResponse;
-import cc.ipconf.ipconfcc.dto.CityDto;
-import cc.ipconf.ipconfcc.dto.CountryDto;
-import cc.ipconf.ipconfcc.config.MMDBLoaderConfig;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -29,7 +29,7 @@ public class LocationServiceImpl implements LocationService {
   @Override
   public CountryDto getCountry(String clientIpAddress) {
     CountryDto countryDto = new CountryDto();
-    DatabaseReader reader = mmdbLoader.getDatabaseReader();
+    DatabaseReader reader = mmdbLoader.getCityDatabaseReader();
 
     InetAddress ip = this.getIpAddress(clientIpAddress);
     CountryResponse response = this.getCountryResponse(reader, ip);
@@ -44,7 +44,7 @@ public class LocationServiceImpl implements LocationService {
   @Override
   public CityDto getCity(String clientIpAddress) {
     CityDto cityDto = new CityDto();
-    DatabaseReader reader = mmdbLoader.getDatabaseReader();
+    DatabaseReader reader = mmdbLoader.getCityDatabaseReader();
 
     InetAddress ip = this.getIpAddress(clientIpAddress);
     CityResponse response = this.getCityResponse(reader,ip);

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -20,10 +20,18 @@ management.endpoint.health.show-details=always
 management.health.diskspace.enabled=false
 
 # Application configuration
-# City MMDB filepath
-ipaddr.mmdb.databases.directory=mmdb/
-ipaddr.mmdb.city-filename=dbip-city-lite-2021-08.mmdb
-ipaddr.mmdb.city-database-path=${ipaddr.mmdb.databases.directory}/${ipaddr.mmdb.city-filename}
+
+## ip-db databases path
+ipconf.mmdb.databases.directory=mmdb/
+
+## City database
+ipconf.mmdb.city-database.filename=dbip-city-lite-2021-08.mmdb
+ipconf.mmdb.city-database.path=${ipconf.mmdb.databases.directory}/${ipconf.mmdb.city-database.filename}
+
+## ASN database
+ipconf.mmdb.asn-database.filename=dbip-asn-lite-2021-08.mmdb
+ipconf.mmdb.asn-database.path=${ipconf.mmdb.databases.directory}/${ipconf.mmdb.asn-database.filename}
+
 
 # Sentry
 sentry.dsn=

--- a/src/main/resources/application-production.properties
+++ b/src/main/resources/application-production.properties
@@ -20,10 +20,17 @@ management.endpoint.health.show-details=always
 management.health.diskspace.enabled=false
 
 # Application configuration
-# City MMDB filepath
-ipaddr.mmdb.databases.directory=mmdb/
-ipaddr.mmdb.city-filename=dbip-city-lite-2021-08.mmdb
-ipaddr.mmdb.city-database-path=${ipaddr.mmdb.databases.directory}/${ipaddr.mmdb.city-filename}
+
+## ip-db databases path
+ipconf.mmdb.databases.directory=mmdb/
+
+## City database
+ipconf.mmdb.city-database.filename=dbip-city-lite-2021-08.mmdb
+ipconf.mmdb.city-database.path=${ipconf.mmdb.databases.directory}/${ipconf.mmdb.city-database.filename}
+
+## ASN database
+ipconf.mmdb.asn-database.filename=dbip-asn-lite-2021-08.mmdb
+ipconf.mmdb.asn-database.path=${ipconf.mmdb.databases.directory}/${ipconf.mmdb.asn-database.filename}
 
 # Sentry
 sentry.dsn=


### PR DESCRIPTION
This commit introduces the following changes:

1. Add ASN support for the `/info` endpoint.
2. Add `/asn` endpoint.
3. Add support for `Accept: application/json` header for `/asn` endpoint.
3. Rename mmdb-related properties in production and development properties.

By default (without `Accept: application/json` header) `/asn` endpoint will return text response.